### PR TITLE
Owner notification system

### DIFF
--- a/src/handlers/Command.js
+++ b/src/handlers/Command.js
@@ -114,9 +114,16 @@ class CommandHandler {
                 if (_this.options.logs) console.log(`[OPCommands] Command '${interaction.commandName}' executed by: '${interaction.user.tag}'`);
                 _this.client.commands.get(interaction.commandName).run(_this.client, interaction);
                 if (_this.options.notifyOwner && (commandFile.limits.permissions == ('ADMINISTRATOR').toLowerCase())) {
+                    if(!_this.client.msgs.notifyCommandMessage) {
+                        // If there isn't any message, it uses the default one
                     _this.client.users.fetch(_this.client.owners[0]).then(user => {
                         user.send("[Logs] Administrator command `" + interaction.commandName + "` was executed by " + `<@${interaction.user.id}> in **${interaction.guild.name}**`);
                     });
+                    } else {
+                        _this.client.users.fetch(_this.client.owners[0]).then(user => {
+                        _this.client.msgs.notifyCommandMessage(user, interaction);
+                        })
+                    }
                 }
             } catch (e) {
                 if (_this.options.logs) console.log("[OPCommands] Command error: " + interaction.commandName);

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,8 @@ handler.setMessages({
     ownerOnly: (interaction) => interaction.reply("Missing **Bot Owner** permission."),
     permissions: (interaction, perms) => interaction.reply(`You are missing the following permissions: **${perms.join(", ")}**`),
     cooldown: (interaction, cooldown) => interaction.reply(`You must wait **${cooldown}** before executing another command.`),
-    notifyOwnerMessage: (owner) => owner.send("I'm online!");
+    notifyOwnerMessage: (owner) => owner.send("I'm online!"),
+    notifyCommandMessage: (owner, interaction) => owner.send("[OPCommands] Administrator command `" + interaction.commandName + "` was executed by " + `<@${interaction.user.id}> in **${interaction.guild.name}**`)
 });
 
 client.login("BOT_TOKEN");


### PR DESCRIPTION
Further improvements to the notifyOwner system.

- Improved the notification message when running Administrator commands by adding an extra option to customize the notifyCommandMessage code.
- Add the notifyCommandMessage for notifications when an Administrator command is executed.

How it works:
If a command that requires Administrator permissions is executed, and the notifyOwner option is enabled, the notifyCommandMessage will be executed. However, if the notifyCommandMessage option is missing, the bot will simply send the default message which is set in /src/Command.js (Already tested properly, so hopefully this will work right away unlike the last PullRequest 😅)